### PR TITLE
License detection for old school beta licenses

### DIFF
--- a/app/panel.php
+++ b/app/panel.php
@@ -295,7 +295,7 @@ class Panel {
       $type = 'Kirby 2 Professional';
     } else if(str::startsWith($key, 'K2-PERSONAL') and str::length($key) == 44) {
       $type = 'Kirby 2 Personal';
-    } else if(str::length($key) == 32) {
+    } else if(str::length($key) == 32 or (str::startsWith($key, 'BETA') && str::length($key) == 9)) {
       $type = 'Kirby 1';
     } else {
       $key = null;


### PR DESCRIPTION
Hi!

If you remember, in the very old days you gave out free licenses for using kirby in the beta. Mine is a 9 chars long string starting with BETA. I still use it personally, so PRing this for glory and to get rid of the message that I need to buy a license in the panel.